### PR TITLE
owl-opt-lbfgs: allow specifying optional bounds

### DIFF
--- a/src/lbfgs/lbfgs.ml
+++ b/src/lbfgs/lbfgs.ml
@@ -106,11 +106,18 @@ struct
   let fv_hist s = List.rev s.fv_hist
   let prms s = extract s.info s.ps
 
-  let init ?(corrections = 10) ~prms0 () =
+  let init ?(corrections = 10) ?l ?u ~prms0 () =
     let n_prms, info = build_info prms0 in
     let ps = Array1.create float64 c_layout n_prms in
     blit AD.primal info prms0 ps;
-    let work = Bindings.start ~corrections n_prms in
+    let vec_of_bound prms_float =
+        let a1 = Array1.create float64 c_layout n_prms in
+        blit Fn.id info prms_float a1;
+        a1
+    in
+    let l = Option.map ~f:vec_of_bound l
+    and u = Option.map ~f:vec_of_bound u in
+    let work = Bindings.start ~corrections ?l ?u n_prms in
     { ps; n_prms; fv_hist = []; info; k = 0; work }
 
 

--- a/src/lbfgs/lbfgs_intf.ml
+++ b/src/lbfgs/lbfgs_intf.ml
@@ -38,7 +38,7 @@ module type Sig = sig
   val fv_hist : state -> float list
 
   (** [init ?corrections ~prms0 ()] returns an initialises optimisation state for initial parmaters [prms0] *)
-  val init : ?corrections:int -> prms0:prms -> unit -> state
+  val init : ?corrections:int -> ?l:prms -> ?u:prms -> prms0:prms -> unit -> state
 
   (** [min ~f state] minimises [f] with respect to the state [s] 
 


### PR DESCRIPTION
The name of the algorithm implies that some bounds could be specified, so expose these in owl-opt-lbfgs's 'init' function:
they were already present in the bindings.