### PR TITLE
lbfgs: fix check_work

### DIFF
--- a/src/lbfgs/bindings.ml
+++ b/src/lbfgs/bindings.ml
@@ -117,7 +117,7 @@ let restart w = set_start w.task
 let check_work n work =
   let corrections = work.corrections in
   if Array1.dim work.wa < wa_min_size n corrections
-     || Array1.dim work.iwa < 3 * corrections
+     || Array1.dim work.iwa < 3 * n
   then (
     let n_min =
       min (wa_n_of_size (Array1.dim work.wa) corrections) (Array1.dim work.iwa / 3)


### PR DESCRIPTION
I got this error, which doesn't make sense because 2 is <= 2:
```
Fatal error: exception Failure("Lbfgs.min: dim of work too small for problem size n = 2, valid n <= 2")
```

iwa is allocated as 3*n, and upstream L-BFGS-ocaml checks for 3*n too, the check against 3*corrections seems to be a typo, looking at lbfgsb.f says '3*nmax' and the code has `iwa.(2*n+1)` so clearly related to 'n' and not 'corrections'.